### PR TITLE
fix: error when trying to delegate from ledger

### DIFF
--- a/imports/api/chain/server/methods.js
+++ b/imports/api/chain/server/methods.js
@@ -71,6 +71,21 @@ Meteor.methods({
       }
       chain.activeVotingPower = activeVP;
 
+      // Staking parameters must be fetched since removal of 
+      // readGenesis setting. They are needed for delegate button
+      // from a Ledger on validator page.
+      url = LCD + '/staking/parameters';
+      try {
+        response = HTTP.get(url);
+        let params = JSON.parse(response.content).result;
+        chain.staking = {
+          params: params
+        };
+      }
+      catch (e) {
+        console.log(url);
+        console.log(e);
+      }
 
       Chain.update({ chainId: chain.chainId }, { $set: chain }, { upsert: true });
       // Get chain states


### PR DESCRIPTION
Clicking the delegate button from a validator page when having connected
a ledger device is reporting a generic error "something goes wrong..."

With debug mode active, it shows a `TypeError: Cannot read property
'unbonding_time' of null` from the validator page component.

Root issue comes from the sync service, which doesn't pull and store the
chain staking parameters from the RPC endpoint. Previously, it was taken
from the genesis file, but this mean it wouldn't be updated in case of
governance vote to change them.

This add a proper pull from RPC of the staking parameters, storing them
at the expected location for the Ledger action buttons to work.
