### PR TITLE
chore: update gas prices

### DIFF
--- a/settings-files/andromeda.json
+++ b/settings-files/andromeda.json
@@ -29,7 +29,7 @@
             "coinType": 118,
             "appName": "Cosmos",
             "appVersion": "2.16.0",
-            "gasPrice": 0.02
+            "gasPrice": 5000000000
         },
         "modules": {
             "bank": true,

--- a/settings-files/fetchhub.json
+++ b/settings-files/fetchhub.json
@@ -29,7 +29,7 @@
       "coinType": 118,
       "appName": "Cosmos",
       "appVersion": "2.16.0",
-      "gasPrice": 0.02
+      "gasPrice": 5000000000
     },
     "modules": {
       "bank": true,

--- a/settings-files/localnet.json
+++ b/settings-files/localnet.json
@@ -29,7 +29,7 @@
       "coinType": 118,
       "appName": "Cosmos",
       "appVersion": "2.16.0",
-      "gasPrice": 0.02
+      "gasPrice": 5000000000
     },
     "modules": {
       "bank": true,

--- a/settings-files/stargateworld.json
+++ b/settings-files/stargateworld.json
@@ -29,7 +29,7 @@
       "coinType": 118,
       "appName": "Cosmos",
       "appVersion": "2.16.0",
-      "gasPrice": 0.02
+      "gasPrice": 5000000000
     },
     "modules": {
       "bank": true,


### PR DESCRIPTION
This PR updates the gas price configurations for the localnet, stargateworld, andromeda, and mainnet to match the "average" price that was set in our [keplr fork's gas prices config](https://github.com/fetchai/keplr-extension/blob/master/packages/extension/src/config.ts).

I have not been able to test these changes as it seems that a Ledger device is required to operate an account in the app (and I don't currently have one).