### PR TITLE
fix: tx broadcast on removed endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ This project is a fork from the excellent [Big Dipper](https://github.com/forbol
 
 ```sh
 meteor npm install --save
-meteor --settings settings.json
+SERVER_NODE_OPTIONS="--no-wasm-code-gc" meteor --settings settings.json
 ```
 
 ### Run via docker-compose
 ```sh
-METEOR_SETTINGS=$(cat settings.json) docker-compose up
+docker-compose up
 ```
 
 ### Run in production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,11 @@ services:
     depends_on:
       - mongo
     environment:
-      ROOT_URL: ${APP_ROOT_URL:-http://localhost}
+      BLOCKEXPLORERURL: ${APP_ROOT_URL:-http://localhost}
       MONGO_URL: mongodb://mongo:27017/meteor
       PORT: 3000
-      METEOR_SETTINGS: ${METEOR_SETTINGS}
+    volumes:
+      - ./settings-files/fetchhub.json:/config/settings.json:ro
 
   mongo:
     image: mongo:latest

--- a/entrypoints/start.sh
+++ b/entrypoints/start.sh
@@ -9,4 +9,5 @@ cd /opt/big_dipper/bundle/programs/server && npm install --production
 
 export PORT=3000
 export METEOR_SETTINGS="$(cat $METEOR_SETTINGS_FILE)"
-node /opt/big_dipper/bundle/main.js
+# --no-wasm-code-gc fix "archived threads in combination with wasm not supported" ¯\_(ツ)_/¯
+node --no-wasm-code-gc /opt/big_dipper/bundle/main.js

--- a/imports/api/ledger/server/methods.js
+++ b/imports/api/ledger/server/methods.js
@@ -1,65 +1,79 @@
-import { HTTP } from 'meteor/http';
-import { Validators } from '../../validators/validators';
+import { HTTP } from "meteor/http";
+import { Validators } from "../../validators/validators";
 
 Meteor.methods({
-    'transaction.submit': function(txInfo) {
-        this.unblock();
-        const url = `${API}/txs`;
-        data = {
-            "tx": txInfo.value,
-            "mode": "sync"
-        }
-        const timestamp = new Date().getTime();
-        console.log(`submitting transaction${timestamp} ${url} with data ${JSON.stringify(data)}`)
+  "transaction.submit": function (txInfo) {
+    this.unblock();
+    const url = `${API}/txs`;
+    data = {
+      tx: txInfo.value,
+      mode: "sync",
+    };
+    const timestamp = new Date().getTime();
+    console.log(
+      `submitting transaction${timestamp} ${url} with data ${JSON.stringify(
+        data
+      )}`
+    );
 
-        let response = HTTP.post(url, { data });
-        console.log(`response for transaction${timestamp} ${url}: ${JSON.stringify(response)}`)
-        if (response.statusCode == 200) {
-            let data = response.data
-            if (data.code)
-                throw new Meteor.Error(data.code, JSON.parse(data.raw_log).message)
-            return response.data.txhash;
-        }
-    },
-    'transaction.execute': function(body, path) {
-        this.unblock();
-        const url = `${API}/${path}`;
-        data = {
-            "base_req": {
-                ...body,
-                "chain_id": Meteor.settings.public.chainId,
-                "simulate": false
-            }
-        };
-        let response = HTTP.post(url, { data });
-        if (response.statusCode == 200) {
-            return JSON.parse(response.content);
-        }
-    },
-    'transaction.simulate': function(txMsg, from, accountNumber, sequence, path, adjustment='1.2') {
-        this.unblock();
-        const url = `${API}/${path}`;
-        console.log(txMsg);
-        data = {...txMsg,
-            "base_req": {
-                "from": from,
-                "chain_id": Meteor.settings.public.chainId,
-                "gas_adjustment": adjustment,
-                "account_number": accountNumber,
-                "sequence": sequence.toString(),
-                "simulate": true
-            }
-        };
-        console.log(url);
-        console.log(data);
-        let response = HTTP.post(url, {data});
-        if (response.statusCode == 200) {
-            return JSON.parse(response.content).gas_estimate;
-        }
-    },
-    'isValidator': function(address){
-        this.unblock();
-        let validator = Validators.findOne({delegator_address:address})
-        return validator;
+    let response = HTTP.post(url, { data });
+    console.log(
+      `response for transaction${timestamp} ${url}: ${JSON.stringify(response)}`
+    );
+    if (response.statusCode == 200) {
+      let data = response.data;
+      if (data.code)
+        throw new Meteor.Error(data.code, JSON.parse(data.raw_log).message);
+      return response.data.txhash;
     }
-})
+  },
+  "transaction.execute": function (body, path) {
+    this.unblock();
+    const url = `${API}/${path}`;
+    data = {
+      base_req: {
+        ...body,
+        chain_id: Meteor.settings.public.chainId,
+        simulate: false,
+      },
+    };
+    let response = HTTP.post(url, { data });
+    if (response.statusCode == 200) {
+      return JSON.parse(response.content);
+    }
+  },
+  "transaction.simulate": function (
+    txMsg,
+    from,
+    accountNumber,
+    sequence,
+    path,
+    adjustment = "1.2"
+  ) {
+    this.unblock();
+    const url = `${API}/${path}`;
+    console.log(txMsg);
+    data = {
+      ...txMsg,
+      base_req: {
+        from: from,
+        chain_id: Meteor.settings.public.chainId,
+        gas_adjustment: adjustment,
+        account_number: accountNumber,
+        sequence: sequence.toString(),
+        simulate: true,
+      },
+    };
+    console.log(url);
+    console.log(data);
+    let response = HTTP.post(url, { data });
+    if (response.statusCode == 200) {
+      return JSON.parse(response.content).gas_estimate;
+    }
+  },
+  isValidator: function (address) {
+    this.unblock();
+    let validator = Validators.findOne({ delegator_address: address });
+    return validator;
+  },
+});

--- a/imports/api/ledger/server/methods.js
+++ b/imports/api/ledger/server/methods.js
@@ -1,30 +1,93 @@
 import { HTTP } from "meteor/http";
 import { Validators } from "../../validators/validators";
 
+import {
+  encodePubkey,
+  makeAuthInfoBytes,
+  Registry,
+} from "@cosmjs/proto-signing";
+import {
+  createAuthzAminoConverters,
+  createBankAminoConverters,
+  createDistributionAminoConverters,
+  createGovAminoConverters,
+  createStakingAminoConverters,
+  createIbcAminoConverters,
+  createFreegrantAminoConverters,
+  defaultRegistryTypes,
+  AminoTypes,
+} from "@cosmjs/stargate";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { Int53 } from "@cosmjs/math";
+import { fromBase64, toBase64 } from "@cosmjs/encoding";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
+
 Meteor.methods({
   "transaction.submit": function (txInfo) {
     this.unblock();
-    const url = `${API}/txs`;
-    data = {
-      tx: txInfo.value,
-      mode: "sync",
-    };
+    const url = `${API}/cosmos/tx/v1beta1/txs`;
     const timestamp = new Date().getTime();
     console.log(
-      `submitting transaction${timestamp} ${url} with data ${JSON.stringify(
-        data
+      `submitting transaction${timestamp} ${url} with data before encoding: ${JSON.stringify(
+        txInfo
       )}`
     );
+
+    legacyTx = txInfo.value;
+    // Encode legacy StdTx to proto bytes needed by /cosmos/tx/v1beta1/txs endpoint
+    let registry = new Registry(defaultRegistryTypes);
+    let aminoTypes = new AminoTypes({
+      ...createAuthzAminoConverters(),
+      ...createBankAminoConverters(),
+      ...createDistributionAminoConverters(),
+      ...createGovAminoConverters(),
+      ...createStakingAminoConverters("fetch"),
+      ...createIbcAminoConverters(),
+      ...createFreegrantAminoConverters(),
+    });
+    const signedTxBody = {
+      typeUrl: "/cosmos.tx.v1beta1.TxBody",
+      value: {
+        messages: legacyTx.msg.map((msg) => aminoTypes.fromAmino(msg)),
+        memo: legacyTx.memo,
+      },
+    };
+    console.log("signed tx body", JSON.stringify(signedTxBody));
+    const signedTxBodyBytes = registry.encode(signedTxBody);
+    const signedGasLimit = Int53.fromString(legacyTx.fee.gas).toNumber();
+    const signedSequence = Int53.fromString(
+      legacyTx.signatures[0].sequence
+    ).toNumber();
+
+    const pubkey = encodePubkey(legacyTx.signatures[0].pub_key);
+
+    const signedAuthInfoBytes = makeAuthInfoBytes(
+      [{ pubkey, sequence: signedSequence }],
+      legacyTx.fee.amount,
+      signedGasLimit,
+      SignMode.SIGN_MODE_LEGACY_AMINO_JSON
+    );
+
+    const rawTx = TxRaw.fromPartial({
+      bodyBytes: signedTxBodyBytes,
+      authInfoBytes: signedAuthInfoBytes,
+      signatures: [fromBase64(legacyTx.signatures[0].signature)],
+    });
+
+    let data = {
+      tx_bytes: toBase64(TxRaw.encode(rawTx).finish()),
+      mode: "BROADCAST_MODE_SYNC",
+    };
 
     let response = HTTP.post(url, { data });
     console.log(
       `response for transaction${timestamp} ${url}: ${JSON.stringify(response)}`
     );
     if (response.statusCode == 200) {
-      let data = response.data;
+      let data = response.data.tx_response;
       if (data.code)
         throw new Meteor.Error(data.code, JSON.parse(data.raw_log).message);
-      return response.data.txhash;
+      return data.txhash;
     }
   },
   "transaction.execute": function (body, path) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,178 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@confio/ics23": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
+      "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
+      "requires": {
+        "@noble/hashes": "^1.0.0",
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "@cosmjs/amino": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.28.1.tgz",
+      "integrity": "sha512-7CihIqU3YOE0dEa1e/dWDMetxmAjYa44P0trmU8cU5TU2JnCBPfjF4hZcTPfoZ4KXNKPQrqAWuLxy0YB6o/5/Q==",
+      "requires": {
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1"
+      }
+    },
+    "@cosmjs/crypto": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.1.tgz",
+      "integrity": "sha512-QLgP+xvd3X4vNU9PPnEGc1PI5qctgg1o6ANivqHgiJdX2bFolsqCqFQDs1rvGf8GWLJ2eGwXZPX1c/QK0bT9+A==",
+      "requires": {
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        }
+      }
+    },
+    "@cosmjs/encoding": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.28.1.tgz",
+      "integrity": "sha512-FqKc+P5rBKq8hW2WHF6L8dmSJhy9mVBDhnJNCLUwyiKBywY9m4BZNTa0mPVQSXISx/c5DPbpJ5SChGL72qNgBw==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "@cosmjs/json-rpc": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.28.1.tgz",
+      "integrity": "sha512-yuOxhrE5ldJDcXhSbtdadAB5GBOGZkcDnZe+v70KcRf09qM81XPYiYfoMsxO9rb1QzThLlAbBx/kRebtzZPwDw==",
+      "requires": {
+        "@cosmjs/stream": "0.28.1",
+        "xstream": "^11.14.0"
+      }
+    },
+    "@cosmjs/math": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.1.tgz",
+      "integrity": "sha512-rF5q4BSwNBo0kNBi8asaoHsRx/TchJ/P4IlRjXY8UGCfKCkSRQEID3ffgE8naXf+BDn5x4cSC8da3xy/aCZpAA==",
+      "requires": {
+        "bn.js": "^5.2.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        }
+      }
+    },
+    "@cosmjs/proto-signing": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.28.1.tgz",
+      "integrity": "sha512-dmBVV/b3x2mxwiEEdLFBpagr6R/X74R0AJLCxaKDwK4FpI4vSz84pOe5J6c9ffHHXnWp129M+pRBBE2S9tK0Cg==",
+      "requires": {
+        "@cosmjs/amino": "0.28.1",
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
+        "cosmjs-types": "^0.4.0",
+        "long": "^4.0.0",
+        "protobufjs": "~6.10.2"
+      }
+    },
+    "@cosmjs/socket": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.28.1.tgz",
+      "integrity": "sha512-fFClGMOdBF3Jsti929AXoywsu6TtEKALxmwPvRYEsbrurLy9Ko28qoWdPFUvQw5WEy5rkzDq+3DKK5tbzsbQNA==",
+      "requires": {
+        "@cosmjs/stream": "0.28.1",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.7",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
+        }
+      }
+    },
+    "@cosmjs/stargate": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.28.1.tgz",
+      "integrity": "sha512-6mHHI2pkqb/khRTWRATODNieEv3PFhnUKgxkdiw39111oN35TTuSwxpT1c2le/VheoiaSZtBotDgL60wUP9LGA==",
+      "requires": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/proto-signing": "0.28.1",
+        "@cosmjs/stream": "0.28.1",
+        "@cosmjs/tendermint-rpc": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
+        "cosmjs-types": "^0.4.0",
+        "long": "^4.0.0",
+        "protobufjs": "~6.10.2",
+        "xstream": "^11.14.0"
+      }
+    },
+    "@cosmjs/stream": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.28.1.tgz",
+      "integrity": "sha512-lhgPI+vjpnwUOrLJADAA9YReMwbDCohIhuMhXiyXTnJfnUcitTh882LeRueyuynXW7zT1qjzZk1MgdumbDeXiA==",
+      "requires": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "@cosmjs/tendermint-rpc": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.28.1.tgz",
+      "integrity": "sha512-2Mt3Hd0Lp8BB6jnkiWr0U5oDRwOl3pueVFkCgv6XIUX8OKY48o97KOQrqW1BDAMYSL7QuXF7ULpvmRgfJqIxeA==",
+      "requires": {
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/json-rpc": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/socket": "0.28.1",
+        "@cosmjs/stream": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
+        "axios": "^0.21.2",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.14.9",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+        }
+      }
+    },
+    "@cosmjs/utils": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.28.1.tgz",
+      "integrity": "sha512-PhdsifctdpMUXeWQjbQiHeOCOhWtK/OXdEG3E2PvvYxlmWHNu1faio+u2gZU6PPjL+qgqlAu92sybwsw/TRa+w=="
+    },
     "@emotion/is-prop-valid": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
@@ -390,6 +562,11 @@
       "integrity": "sha1-iMFN+7Si+iJY//SInM2N3Q7MsEs=",
       "dev": true
     },
+    "@noble/hashes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+      "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+    },
     "@node-a-team/ts-amino": {
       "version": "0.0.1-alpha.2",
       "resolved": "https://registry.npmjs.org/@node-a-team/ts-amino/-/ts-amino-0.0.1-alpha.2.tgz",
@@ -421,6 +598,60 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.0.tgz",
       "integrity": "sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ=="
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@restart/context": {
       "version": "2.1.4",
@@ -673,6 +904,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/meteor-universe-i18n": {
       "version": "1.14.6",
@@ -1604,6 +1840,42 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmjs-types": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.4.1.tgz",
+      "integrity": "sha512-I7E/cHkIgoJzMNQdFF0YVqPlaTqrqKHrskuSTIqlEyxfB5Lf3WKCajSXVK2yHOfOFfSux/RxEdpMzw/eO4DIog==",
+      "requires": {
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "17.0.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+          "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+        },
+        "protobufjs": {
+          "version": "6.11.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+          "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^4.0.0"
+          }
+        }
+      }
     },
     "create-hash": {
       "version": "1.2.0",
@@ -2822,9 +3094,9 @@
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "fibers": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
-      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.1.tgz",
+      "integrity": "sha512-VMC7Frt87Oo0AOJ6EcPFbi+tZmkQ4tD85aatwyWL6I9cYMJmm2e+pXUJsfGZ36U7MffXtjou2XIiWJMtHriErw==",
       "requires": {
         "detect-libc": "^1.0.3"
       }
@@ -3020,6 +3292,14 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
     },
     "graceful-fs": {
       "version": "4.2.6",
@@ -3450,6 +3730,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
@@ -3614,6 +3899,19 @@
         "type-check": "~0.3.2"
       }
     },
+    "libsodium": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
+      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
+    },
+    "libsodium-wrappers": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
+      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
+      "requires": {
+        "libsodium": "^0.7.0"
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -3641,6 +3939,11 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5468,6 +5771,33 @@
         "warning": "^4.0.0"
       }
     },
+    "protobufjs": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+        }
+      }
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -5912,6 +6242,11 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "readonly-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
+      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
     },
     "regenerator-runtime": {
       "version": "0.13.9",
@@ -6412,6 +6747,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -6898,6 +7238,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
+    "xstream": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
+      "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
+      "requires": {
+        "globalthis": "^1.0.1",
+        "symbol-observable": "^2.0.3"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "styled-components": "^4.4.1",
     "tendermint": "^5.0.2",
     "tooltip.js": "^1.3.3",
-    "voca": "^1.4.0"
+    "voca": "^1.4.0",
+    "@cosmjs/stargate": "^0.28.1",
+    "cosmjs-types": "^0.4.1"
   },
   "devDependencies": {
     "@meteorjs/eslint-config-meteor": "^1.0.5",

--- a/settings-files/fetchhub.json
+++ b/settings-files/fetchhub.json
@@ -1,9 +1,9 @@
 {
   "public": {
-    "chainName": "fetchhub-2",
-    "chainId": "fetchhub-2",
+    "chainName": "fetchhub-4",
+    "chainId": "fetchhub-4",
     "gtm": "",
-    "genesisTime": "2021-09-16T14:00:00Z",
+    "genesisTime": "2022-04-05T14:00:00Z",
     "slashingWindow": 250,
     "uptimeWindow": 250,
     "initialPageSize": 30,
@@ -23,6 +23,11 @@
         "denom": "afet",
         "displayName": "FET",
         "fraction": 1000000000000000000
+      },
+      {
+        "denom": "nanomobx",
+        "displayName": "MOBX",
+        "fraction": 1000000000
       }
     ],
     "ledger": {
@@ -50,7 +55,7 @@
     "startTimer": true
   },
   "params": {
-    "startHeight": 2436701,
+    "startHeight": 5300201,
     "defaultBlockTime": 5000,
     "validatorUpdateWindow": 300,
     "blockInterval": 15000,


### PR DESCRIPTION
rest `/txs` does not exists anymore on cosmos v0.45. Must now use `cosmos/v1beta1/txs` endpoint, which require a proto encoded tx instead of a legacy tx.